### PR TITLE
Turn transitions

### DIFF
--- a/Global/game_logic.gd
+++ b/Global/game_logic.gd
@@ -276,8 +276,8 @@ func _on_enemy_defeated(enemy: Node2D):
 ##player or enemy turns back-to-back won't have a pause
 func transition_handler() -> void:
 	if(active_entity.is_in_group("player")):
+		player_turn.emit()
 		if current_game_status != game_status.PLAYERTURN:
-			player_turn.emit()
 			await get_tree().create_timer(1.0).timeout
 		current_game_status = game_status.PLAYERTURN
 	elif(active_entity.is_in_group("monster")):

--- a/Global/game_logic.gd
+++ b/Global/game_logic.gd
@@ -4,6 +4,7 @@ extends Node
 signal round_passed
 signal player_turn
 signal enemy_turn
+#these signals will be used with handling transitions in the turn system
 signal combat_started
 signal combat_ended
 signal start_turn(entity) #emitted to all monsters, if the entity reference matches
@@ -230,6 +231,7 @@ func combat_start():
 func combat_loop() ->void:
 	while(in_combat):
 		#a transition function should be included here for better separation between turns
+		transition_handler()
 		start_turn.emit(turn_order[current_turn_index])
 		active_entity = turn_order[current_turn_index]
 		print("Turn active for ", turn_order[current_turn_index])
@@ -255,10 +257,6 @@ func _on_enemy_defeated(enemy: Node2D):
 		current_turn_index -= 1
 	turn_order.erase(enemy)
 	entities.erase(enemy)
-	#bug: this iterates the turn index before the end turn signal fires
-	#since the end turn signal won't match the turn index, round_passed never fires
-	#the next active entity never receives it's start turn signal, and the game softlocks
-	##fixed
 	print_debug("Turn order is now ", turn_order)
 	#the quick pans keep going to strange positions
 	camera_quick_pan.emit(enemy.global_position)
@@ -272,6 +270,12 @@ func _on_enemy_defeated(enemy: Node2D):
 		combat_ended.emit()
 		print_debug("Combat has ended")
 	return
+
+##this function will handle pauses in the turn system and signal when a player or enemy turn starts
+##the intent is that a pause only occurs when transitioning between the two types of turn
+##player or enemy turns back-to-back won't have a pause
+func transition_handler() -> void:
+	pass
 
 #func _on_property_list_changed() -> void:
 	#if in_combat == true:

--- a/Scenes/UI/gameplay_hud.tscn
+++ b/Scenes/UI/gameplay_hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://bjk146k4p6yho"]
+[gd_scene load_steps=12 format=3 uid="uid://bjk146k4p6yho"]
 
 [ext_resource type="Script" path="res://Scenes/UI/hud_logic.gd" id="1_c74vo"]
 [ext_resource type="PackedScene" uid="uid://83lbldk0ei0i" path="res://Scenes/spell_hotbar.tscn" id="2_4g6re"]
@@ -9,6 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://dm85s7bcj2sdw" path="res://Scenes/Components/resource_labels.tscn" id="7_anc3g"]
 [ext_resource type="Script" path="res://Scenes/debug_controls.gd" id="8_o7yxl"]
 [ext_resource type="PackedScene" uid="uid://h60cra5dw2bk" path="res://Scenes/UI/pause_menu.tscn" id="9_t0nal"]
+[ext_resource type="PackedScene" uid="uid://xnfn7a5leew1" path="res://Scenes/UI/transition_event.tscn" id="10_hx0d1"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_ofr2f"]
 font_size = 32
@@ -26,6 +27,7 @@ offset_bottom = 1170.0
 scale = Vector2(0.125, 0.125)
 
 [node name="HeartGUI" parent="." instance=ExtResource("3_cnv8t")]
+unique_name_in_owner = true
 scale = Vector2(0.25, 0.25)
 
 [node name="DummyHearts" type="Sprite2D" parent="HeartGUI"]
@@ -70,6 +72,7 @@ offset_top = 130.0
 offset_bottom = 224.0
 
 [node name="DebugControls" type="Control" parent="." groups=["debug"]]
+unique_name_in_owner = true
 layout_mode = 3
 anchors_preset = 2
 anchor_top = 1.0
@@ -107,6 +110,11 @@ tooltip_text = "HOTKEY: Esc"
 text = "Pause"
 
 [node name="PauseMenu" parent="." instance=ExtResource("9_t0nal")]
+unique_name_in_owner = true
+visible = false
+
+[node name="TransitionEvent" parent="." instance=ExtResource("10_hx0d1")]
+unique_name_in_owner = true
 visible = false
 
 [connection signal="pressed" from="DebugControls/EnableCombat" to="DebugControls" method="_on_enable_combat_pressed"]

--- a/Scenes/UI/gameplay_hud.tscn
+++ b/Scenes/UI/gameplay_hud.tscn
@@ -52,6 +52,7 @@ value = 0.0
 visible = false
 
 [node name="TurnStatus" type="Label" parent="."]
+visible = false
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5

--- a/Scenes/UI/hud_logic.gd
+++ b/Scenes/UI/hud_logic.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 	GameLogic.add_listener('player_turn', self, '_on_player_turn')
 	GameLogic.add_listener('enemy_turn', self, '_on_enemy_turn')
 	resource_labels.visible = GameLogic.in_combat
-	turn_label.visible = GameLogic.in_combat
+	#turn_label.visible = GameLogic.in_combat
 	$CalorieMeter.value = PlayerData.current_data["Calories"]
 	$CalorieMeter.max_value = PlayerData.current_data["MaxCalories"]
 	$CalorieMeter/Label.text = str(PlayerData.current_data["Calories"], "/", PlayerData.current_data["MaxCalories"])
@@ -66,7 +66,7 @@ func _update_hotbar():
 	pass
 
 func _on_combat_start():
-	turn_label.visible = true
+	#turn_label.visible = true
 	turn_label.text = "Combat started"
 	resource_labels.visible = true
 
@@ -79,17 +79,20 @@ func _on_combat_start():
 	#else: turn_label.text = "idk how you managed to get this text"
 	
 func _on_player_turn():
-	turn_label.text = "Player turn"
-	#transition event
+	#turn_label.text = "Player turn"
+	event_message("Player Turn Start")
+	return
 
 func _on_enemy_turn():
-	turn_label.text = "Enemy turn"
-	#transition event
+	#turn_label.text = "Enemy turn"
+	event_message("Enemy Turn Start")
+	return
 
 func _on_combat_end():
-	turn_label.text = "Not in combat"
+	#turn_label.text = "Not in combat"
 	resource_labels.visible = false
 	turn_label.visible = false
+	event_message("Combat Over")
 	return
 
 func _on_pause_button_pressed() -> void:
@@ -105,6 +108,7 @@ func _on_game_over(cause: String) -> void:
 	%PauseButton.visible = false
 
 func event_message(message : String) -> void:
-	#I'm noticing the text would be a headache to edit from here
-	%TransitionEvent/AnimationPlayer.play("phase_transition")
-	pass
+	##I decided to create the function within the transition gui scene as retrieving the nodes from gameplay hud is a hassle
+	transition_event.visible = true
+	transition_event.play_transition(message)
+	return

--- a/Scenes/UI/hud_logic.gd
+++ b/Scenes/UI/hud_logic.gd
@@ -4,7 +4,8 @@ extends CanvasLayer
 @onready var hearts = $HeartGUI
 @onready var turn_label = $TurnStatus
 @onready var resource_labels = $ResourceLabels
-var player_reference
+@onready var transition_event = %TransitionEvent
+var player_reference #redundant because the global variable can be sued
 signal paused
 
 # Called when the node enters the scene tree for the first time.
@@ -79,9 +80,11 @@ func _on_combat_start():
 	
 func _on_player_turn():
 	turn_label.text = "Player turn"
+	#transition event
 
 func _on_enemy_turn():
 	turn_label.text = "Enemy turn"
+	#transition event
 
 func _on_combat_end():
 	turn_label.text = "Not in combat"
@@ -100,3 +103,8 @@ func _on_unpaused() -> void:
 func _on_game_over(cause: String) -> void:
 	$PauseMenu.reveal("GameOver", cause)
 	%PauseButton.visible = false
+
+func event_message(message : String) -> void:
+	#I'm noticing the text would be a headache to edit from here
+	%TransitionEvent/AnimationPlayer.play("phase_transition")
+	pass

--- a/Scenes/UI/hud_logic.gd
+++ b/Scenes/UI/hud_logic.gd
@@ -80,7 +80,10 @@ func _on_combat_start():
 	
 func _on_player_turn():
 	#turn_label.text = "Player turn"
-	event_message("Player Turn Start")
+	if GameLogic.current_game_status == GameLogic.game_status.PLAYERTURN:
+		event_message("Go Again!") #This happens when the player has multiple turns back to back
+	else:
+		event_message("Player Turn Start")
 	return
 
 func _on_enemy_turn():

--- a/Scenes/UI/hud_logic.gd
+++ b/Scenes/UI/hud_logic.gd
@@ -21,6 +21,7 @@ func _ready() -> void:
 	GameLogic.add_listener("combat_ended", self, "_on_combat_end")
 	GameLogic.add_listener('game_over', self, '_on_game_over')
 	GameLogic.add_listener('player_turn', self, '_on_player_turn')
+	GameLogic.add_listener('enemy_turn', self, '_on_enemy_turn')
 	resource_labels.visible = GameLogic.in_combat
 	turn_label.visible = GameLogic.in_combat
 	$CalorieMeter.value = PlayerData.current_data["Calories"]
@@ -59,6 +60,7 @@ func _update_calories(new_amount: int = 0, _difference: int = 0):
 		$CalorieMeter/AnimationPlayer.stop()
 	return
 
+##the hotbar buttons will be grayed out when the abilities are unavailable or disappear if the ability is locked or a cutscene is active
 func _update_hotbar():
 	pass
 

--- a/Scenes/UI/transition_event.tscn
+++ b/Scenes/UI/transition_event.tscn
@@ -1,7 +1,44 @@
-[gd_scene load_steps=2 format=3 uid="uid://xnfn7a5leew1"]
+[gd_scene load_steps=5 format=3 uid="uid://xnfn7a5leew1"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_85shs"]
 font_size = 32
+
+[sub_resource type="Animation" id="Animation_r4phc"]
+resource_name = "phase_transition"
+length = 3.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Panel:size")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(132, 0), Vector2(1280, 40)]
+}
+
+[sub_resource type="Animation" id="Animation_ke04l"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Panel:size")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(132, 40)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_7xipp"]
+_data = {
+"RESET": SubResource("Animation_ke04l"),
+"phase_transition": SubResource("Animation_r4phc")
+}
 
 [node name="TransitionEvent" type="Control"]
 layout_mode = 3
@@ -22,9 +59,8 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -66.0
-offset_top = -20.0
 offset_right = 66.0
-offset_bottom = 20.0
+offset_bottom = 40.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -45,3 +81,6 @@ text = "Turn"
 label_settings = SubResource("LabelSettings_85shs")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_7xipp")
+}

--- a/Scenes/UI/transition_event.tscn
+++ b/Scenes/UI/transition_event.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://xnfn7a5leew1"]
+[gd_scene load_steps=6 format=3 uid="uid://xnfn7a5leew1"]
+
+[ext_resource type="Script" path="res://Scenes/UI/transition_event_gui.gd" id="1_1ed60"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_85shs"]
 font_size = 32
@@ -32,7 +34,7 @@ tracks/1/keys = {
 
 [sub_resource type="Animation" id="Animation_r4phc"]
 resource_name = "phase_transition"
-length = 1.5
+length = 2.0
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -40,7 +42,7 @@ tracks/0/path = NodePath("Panel:size")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.4, 0.8, 1.2),
+"times": PackedFloat32Array(0, 0.5, 1.5, 2),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
 "values": [Vector2(1280, 0), Vector2(1280, 40), Vector2(1280, 40), Vector2(1280, 0)]
@@ -52,7 +54,7 @@ tracks/1/path = NodePath("Panel/TextPositionControl:position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.4, 0.8, 1.2),
+"times": PackedFloat32Array(0, 0.5, 1.5, 2),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
 "values": [Vector2(-60, 20), Vector2(640, 20), Vector2(640, 20), Vector2(1340, 20)]
@@ -73,6 +75,7 @@ anchor_right = 0.5
 anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_1ed60")
 
 [node name="Panel" type="Panel" parent="."]
 clip_contents = true
@@ -83,8 +86,7 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -640.0
-offset_right = -508.0
-offset_bottom = 40.0
+offset_right = 640.0
 grow_horizontal = 2
 grow_vertical = 2
 pivot_offset = Vector2(640, 20)
@@ -96,12 +98,15 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = 574.0
-offset_right = 574.0
+offset_left = 700.0
+offset_top = 20.0
+offset_right = 700.0
+offset_bottom = 20.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="Label" type="Label" parent="Panel/TextPositionControl"]
+[node name="Text" type="Label" parent="Panel/TextPositionControl"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(80, 50)
 layout_mode = 1
 anchors_preset = 8
@@ -124,3 +129,5 @@ vertical_alignment = 1
 libraries = {
 "": SubResource("AnimationLibrary_7xipp")
 }
+
+[connection signal="animation_finished" from="AnimationPlayer" to="." method="_on_animation_player_animation_finished"]

--- a/Scenes/UI/transition_event.tscn
+++ b/Scenes/UI/transition_event.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=2 format=3 uid="uid://xnfn7a5leew1"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_85shs"]
+font_size = 32
+
+[node name="TransitionEvent" type="Control"]
+layout_mode = 3
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Panel" type="Panel" parent="."]
+clip_contents = true
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -66.0
+offset_top = -20.0
+offset_right = 66.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = -11.5
+offset_right = 20.0
+offset_bottom = 11.5
+grow_horizontal = 2
+grow_vertical = 2
+text = "Turn"
+label_settings = SubResource("LabelSettings_85shs")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/Scenes/UI/transition_event.tscn
+++ b/Scenes/UI/transition_event.tscn
@@ -3,22 +3,6 @@
 [sub_resource type="LabelSettings" id="LabelSettings_85shs"]
 font_size = 32
 
-[sub_resource type="Animation" id="Animation_r4phc"]
-resource_name = "phase_transition"
-length = 3.0
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Panel:size")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.4),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(132, 0), Vector2(1280, 40)]
-}
-
 [sub_resource type="Animation" id="Animation_ke04l"]
 length = 0.001
 tracks/0/type = "value"
@@ -32,6 +16,46 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 0,
 "values": [Vector2(132, 40)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Panel/TextPositionControl:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(640, 20)]
+}
+
+[sub_resource type="Animation" id="Animation_r4phc"]
+resource_name = "phase_transition"
+length = 1.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Panel:size")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4, 0.8, 1.2),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Vector2(1280, 0), Vector2(1280, 40), Vector2(1280, 40), Vector2(1280, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Panel/TextPositionControl:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.4, 0.8, 1.2),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Vector2(-60, 20), Vector2(640, 20), Vector2(640, 20), Vector2(1340, 20)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_7xipp"]
@@ -58,27 +82,43 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -66.0
-offset_right = 66.0
+offset_left = -640.0
+offset_right = -508.0
 offset_bottom = 40.0
 grow_horizontal = 2
 grow_vertical = 2
+pivot_offset = Vector2(640, 20)
 
-[node name="Label" type="Label" parent="Panel"]
+[node name="TextPositionControl" type="Control" parent="Panel"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -20.0
-offset_top = -11.5
-offset_right = 20.0
-offset_bottom = 11.5
+offset_left = 574.0
+offset_right = 574.0
 grow_horizontal = 2
 grow_vertical = 2
-text = "Turn"
+
+[node name="Label" type="Label" parent="Panel/TextPositionControl"]
+custom_minimum_size = Vector2(80, 50)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -43.0
+offset_top = -25.0
+offset_right = 43.0
+offset_bottom = 25.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Event"
 label_settings = SubResource("LabelSettings_85shs")
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Scenes/UI/transition_event_gui.gd
+++ b/Scenes/UI/transition_event_gui.gd
@@ -1,0 +1,10 @@
+extends Control
+
+func play_transition(message : String) -> void:
+	%Text.text = message
+	$AnimationPlayer.play("phase_transition")
+	return
+
+func _on_animation_player_animation_finished(anim_name: StringName) -> void:
+	visible = false
+	return

--- a/Scenes/main_menu.gd
+++ b/Scenes/main_menu.gd
@@ -18,10 +18,6 @@ func _ready() -> void:
 	##the intent is on the main menu, the Mystic Intro will play on a loop and won't transition until a level is loaded
 	return
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta: float) -> void:
-	#pass
-
 func _on_diet_mode_button_toggled(toggled_on: bool) -> void:
 	#print_debug("Diet button has value ", toggled_on)
 	DietMode.enabled = toggled_on


### PR DESCRIPTION
Implements a pause between player and enemy turns, complete with a text animation. Any message can be displayed in the text animation, so it could potentially can be used for other events.
![9 27 event message](https://github.com/user-attachments/assets/162e4b56-9db4-4607-b56e-3eeca4d5d1c0)
